### PR TITLE
Unpin runtime dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "typescript": "^3.6.3"
   },
   "dependencies": {
-    "@smartlyio/safe-navigation": "5.0.1",
-    "lodash": "4.17.20",
-    "randexp": "0.5.3"
+    "@smartlyio/safe-navigation": "^5.0.1",
+    "lodash": "^4.17.20",
+    "randexp": "^0.5.3"
   },
   "keywords": [
     "oats",

--- a/renovate.json
+++ b/renovate.json
@@ -1,28 +1,11 @@
 {
   "extends": [
-    "config:base"
+    "config:js-lib"
   ],
   "timezone": "Europe/Helsinki",
   "prHourlyLimit": 5,
   "labels": ["patch"],
   "packageRules": [
-    {
-      "groupName": "Smartly packages",
-      "packagePatterns": [
-        "^@smartly\/"
-      ],
-      "excludePackagePatterns": [
-        "^@smartly\/asset-"
-      ],
-      "schedule": "at any time"
-    },
-    {
-      "groupName": "Smartly Asset Library Components",
-      "packagePatterns": [
-        "^@smartly\/asset-"
-      ],
-      "schedule": "at any time"
-    },
     {
       "groupName": "Smartly Oats",
       "packagePatterns": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -508,6 +508,13 @@
   dependencies:
     lodash "4.17.19"
 
+"@smartlyio/safe-navigation@^5.0.1":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@smartlyio/safe-navigation/-/safe-navigation-5.0.2.tgz#fd2b3583dff4b25f077000a785bc25a7bc39751d"
+  integrity sha512-Y7HZ7RL/AOKZwzwOpU8jlcys7m7ArWW372Fidi1PdCBKNODEfRpm5lyNGw05ClEQ7h/byiCX+lrNcDw9WFt8uA==
+  dependencies:
+    lodash "^4.17.19"
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.9"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.9.tgz#77e59d438522a6fb898fa43dc3455c6e72f3963d"
@@ -3048,15 +3055,15 @@ lodash@4.17.19, lodash@^4.17.19:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
-lodash@4.17.20:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
-
 lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^4.17.20:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 make-dir@^3.0.0:
   version "3.0.2"
@@ -3619,7 +3626,7 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-randexp@0.5.3:
+randexp@^0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.5.3.tgz#f31c2de3148b30bdeb84b7c3f59b0ebb9fec3738"
   integrity sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==


### PR DESCRIPTION
Only pin development dependencies. This improves efficiency of package deduplication and allows dependants to install latest supported version of dependencies without making a release.